### PR TITLE
Add Japanese README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,11 @@
+# codex_tests
+
+このリポジトリには Codex をテストするためのサンプルスクリプトが含まれています。
+
+## 含まれているスクリプト
+
+- `export_classes_csv.py` - Vectorworks のクラス設定を `class_settings.csv` という CSV ファイルにエクスポートします。スクリプトは線色や塗り色、不透明度、テキストスタイルの使用、マーカー情報、ベクターフィルのパターンなど多くの属性を収集します。最近の更新では `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill` といったフィールドが追加されました。
+
+## テスト
+
+`tests` ディレクトリには pytest スイートが含まれています。`tests/test_export_classes_csv.py` は `export_classes_csv.py` が期待通りの CSV を作成することを確認し、Vectorworks API をテスト用にスタブ化する方法を示しています。

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains example scripts for testing Codex.
 
+[日本語のREADMEはこちら](README.ja.md)
+
 ## Included Scripts
 
 - `export_classes_csv.py` - Exports Vectorworks class settings to a CSV file named `class_settings.csv`. The script collects many attributes including line and fill colors, opacities, text style usage, marker data, and vector fill patterns. Recent updates added fields such as `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, and `vector_fill`.


### PR DESCRIPTION
## Summary
- add Japanese README as README.ja.md
- link to the Japanese README from README.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452b262a44832593c9695b9e4125c4
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Documentation: Added a new Japanese README file (README.ja.md) to provide instructions and details about the project in Japanese. This will help Japanese-speaking users understand the project better.
- New Feature: Introduced a script (`export_classes_csv.py`) for exporting classes to a CSV file, as detailed in the Japanese README.
- Documentation: Updated the main README file to include a link to the new Japanese README, making it easily accessible to users.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->