### PR TITLE
Add link to English version in Japanese README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# codex_tests
+# Codex Tests
 
 [English version](./README.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,13 @@
+# codex_tests
+
+[English version](./README.md)
+
+このリポジトリには Codex をテストするためのサンプルスクリプトが含まれています。
+
+## 含まれているスクリプト
+
+- `export_classes_csv.py` - Vectorworks のクラス設定を `class_settings.csv` という CSV ファイルにエクスポートします。スクリプトは線色や塗り色、不透明度、テキストスタイルの使用、マーカー情報、ベクターフィルのパターンなど多くの属性を収集します。最近の更新では `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill` といったフィールドが追加されました。
+
+## テスト
+
+`tests` ディレクトリには pytest スイートが含まれています。`tests/test_export_classes_csv.py` は `export_classes_csv.py` が期待通りの CSV を作成することを確認し、Vectorworks API をテスト用にスタブ化する方法を示しています。

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains example scripts for testing Codex.
 
+[日本語のREADMEはこちら](README.ja.md)
+
 ## Included Scripts
 
 - `export_classes_csv.py` - Exports Vectorworks class settings to a CSV file named `class_settings.csv`. The script collects many attributes including line and fill colors, opacities, text style usage, marker data, and vector fill patterns. Recent updates added fields such as `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, and `vector_fill`.


### PR DESCRIPTION
## Summary
- add `[English version](./README.md)` link at the top of `README.ja.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68452b262a44832593c9695b9e4125c4

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
---
## リリースノート

- 新機能: Codexのテスト用のサンプルスクリプトに関する情報を追加しました。
- ドキュメンテーション: `README.ja.md` と `README.md` の両方に、他の言語バージョンへのリンクを追加しました。これにより、ユーザーは自分の好みの言語でドキュメンテーションを読むことができます。

以上の変更により、エンドユーザーはCodexのテスト方法を理解しやすくなり、また、自分の言語でドキュメンテーションを読むことが可能になります。
---
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->