### PR TITLE
Extend class export script with more attributes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 
 ## 含まれているスクリプト
 
-- `export_classes_csv.py` - Vectorworks のクラス設定を `class_settings.csv` という CSV ファイルにエクスポートします。スクリプトは線色や塗り色、不透明度、テキストスタイルの使用、マーカー情報、ベクターフィルのパターンなど多くの属性を収集します。最近の更新では `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill`, `drop_shadow_enabled` などのフィールドが追加されました。
+- `export_classes_csv.py` - Vectorworks のクラス設定を `class_settings.csv` という CSV ファイルにエクスポートします。スクリプトは線色や塗り色、不透明度、テキストスタイルの使用、マーカー情報、ベクターフィルのパターンなど多くの属性を収集します。最近の更新では `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill`, `drop_shadow_enabled` のほか、`class_options`, `drop_shadow_data`, `line_style_n`, `text_style_ref` の各フィールドが追加されました。
 
 ## テスト
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 
 ## 含まれているスクリプト
 
-- `export_classes_csv.py` - Vectorworks のクラス設定を `class_settings.csv` という CSV ファイルにエクスポートします。スクリプトは線色や塗り色、不透明度、テキストスタイルの使用、マーカー情報、ベクターフィルのパターンなど多くの属性を収集します。最近の更新では `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill`, `drop_shadow_enabled` など `*_by_class` 系のフィールドが追加されました。
+- `export_classes_csv.py` - Vectorworks のクラス設定を `class_settings.csv` という CSV ファイルにエクスポートします。スクリプトは線色や塗り色、不透明度、テキストスタイルの使用、マーカー情報、ベクターフィルのパターンなど多くの属性を収集します。最近の更新では `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill`, `drop_shadow_enabled` などのフィールドが追加されました。
 
 ## テスト
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 
 ## 含まれているスクリプト
 
-- `export_classes_csv.py` - Vectorworks のクラス設定を `class_settings.csv` という CSV ファイルにエクスポートします。スクリプトは線色や塗り色、不透明度、テキストスタイルの使用、マーカー情報、ベクターフィルのパターンなど多くの属性を収集します。最近の更新では `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill` といったフィールドが追加されました。
+- `export_classes_csv.py` - Vectorworks のクラス設定を `class_settings.csv` という CSV ファイルにエクスポートします。スクリプトは線色や塗り色、不透明度、テキストスタイルの使用、マーカー情報、ベクターフィルのパターンなど多くの属性を収集します。最近の更新では `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill`, `drop_shadow_enabled` など `*_by_class` 系のフィールドが追加されました。
 
 ## テスト
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains example scripts for testing Codex.
 
 ## Included Scripts
 
-- `export_classes_csv.py` - Exports Vectorworks class settings to a CSV file named `class_settings.csv`. The script collects many attributes including line and fill colors, opacities, text style usage, marker data, and vector fill patterns. Recent updates added fields such as `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill`, `drop_shadow_enabled`, and several `*_by_class` attributes.
+- `export_classes_csv.py` - Exports Vectorworks class settings to a CSV file named `class_settings.csv`. The script collects many attributes including line and fill colors, opacities, text style usage, marker data, and vector fill patterns. Recent updates added fields such as `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill`, and `drop_shadow_enabled`.
 ## Tests
 
 The `tests` directory contains a pytest suite. The file

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains example scripts for testing Codex.
 
 ## Included Scripts
 
-- `export_classes_csv.py` - Exports Vectorworks class settings to a CSV file named `class_settings.csv`. The script collects many attributes including line and fill colors, opacities, text style usage, marker data, and vector fill patterns. Recent updates added fields such as `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill`, and `drop_shadow_enabled`.
+- `export_classes_csv.py` - Exports Vectorworks class settings to a CSV file named `class_settings.csv`. The script collects many attributes including line and fill colors, opacities, text style usage, marker data, and vector fill patterns. Recent updates added fields such as `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill`, and `drop_shadow_enabled`, `class_options`, `drop_shadow_data`, `line_style_n`, `text_style_ref`.
 ## Tests
 
 The `tests` directory contains a pytest suite. The file

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains example scripts for testing Codex.
 
 ## Included Scripts
 
-- `export_classes_csv.py` - Exports Vectorworks class settings to a CSV file named `class_settings.csv`. The script collects many attributes including line and fill colors, opacities, text style usage, marker data, and vector fill patterns. Recent updates added fields such as `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, and `vector_fill`.
+- `export_classes_csv.py` - Exports Vectorworks class settings to a CSV file named `class_settings.csv`. The script collects many attributes including line and fill colors, opacities, text style usage, marker data, and vector fill patterns. Recent updates added fields such as `use_text_style`, `beginning_marker`, `end_marker`, `by_style`, `opacity_n`, `vector_fill`, `drop_shadow_enabled`, and several `*_by_class` attributes.
 ## Tests
 
 The `tests` directory contains a pytest suite. The file

--- a/export_classes_csv.py
+++ b/export_classes_csv.py
@@ -201,6 +201,68 @@ def get_class_attributes(class_name):
             ['GetClVectorFill', 'GetClassVectorFill'],
             class_name,
         ),
+        'drop_shadow_enabled': _call_vs_function(
+            ['CLDropShadowEnabled'],
+            class_name,
+        ),
+        'fill_color_by_class': _color_to_tuple_string(
+            _call_vs_function(['FillColorByClass'], class_name)
+        ),
+        'fill_pattern_by_class': _call_vs_function(
+            ['FPatByClass'],
+            class_name,
+        ),
+        'class_options': _call_vs_function(
+            ['GetClassOptions'],
+            class_name,
+        ),
+        'drop_shadow_data': _call_vs_function(
+            ['GetCLDrpShadowData'],
+            class_name,
+        ),
+        'line_style_n': _call_vs_function(
+            ['GetClLSN'],
+            class_name,
+        ),
+        'text_style_ref': _call_vs_function(
+            ['GetClTextStyleRef'],
+            class_name,
+        ),
+        'gray_class': _call_vs_function(
+            ['GrayClass'],
+            class_name,
+        ),
+        'hide_class': _call_vs_function(
+            ['HideClass'],
+            class_name,
+        ),
+        'line_style_by_class': _call_vs_function(
+            ['LSByClass'],
+            class_name,
+        ),
+        'line_weight_by_class': _call_vs_function(
+            ['LWByClass'],
+            class_name,
+        ),
+        'marker_by_class': _call_vs_function(
+            ['MarkerByClass'],
+            class_name,
+        ),
+        'name_class': _call_vs_function(
+            ['NameClass'],
+            class_name,
+        ),
+        'opacity_by_class': _call_vs_function(
+            ['OpacityByClass'],
+            class_name,
+        ),
+        'opacity_by_class_n': _call_vs_function(
+            ['OpacityByClassN'],
+            class_name,
+        ),
+        'pen_color_by_class': _color_to_tuple_string(
+            _call_vs_function(['PenColorByClass'], class_name)
+        ),
     }
     return attrs
 

--- a/export_classes_csv.py
+++ b/export_classes_csv.py
@@ -205,10 +205,6 @@ def get_class_attributes(class_name):
             ['CLDropShadowEnabled'],
             class_name,
         ),
-        'fill_pattern_by_class': _call_vs_function(
-            ['FPatByClass'],
-            class_name,
-        ),
         'class_options': _call_vs_function(
             ['GetClassOptions'],
             class_name,
@@ -224,41 +220,6 @@ def get_class_attributes(class_name):
         'text_style_ref': _call_vs_function(
             ['GetClTextStyleRef'],
             class_name,
-        ),
-        'gray_class': _call_vs_function(
-            ['GrayClass'],
-            class_name,
-        ),
-        'hide_class': _call_vs_function(
-            ['HideClass'],
-            class_name,
-        ),
-        'line_style_by_class': _call_vs_function(
-            ['LSByClass'],
-            class_name,
-        ),
-        'line_weight_by_class': _call_vs_function(
-            ['LWByClass'],
-            class_name,
-        ),
-        'marker_by_class': _call_vs_function(
-            ['MarkerByClass'],
-            class_name,
-        ),
-        'name_class': _call_vs_function(
-            ['NameClass'],
-            class_name,
-        ),
-        'opacity_by_class': _call_vs_function(
-            ['OpacityByClass'],
-            class_name,
-        ),
-        'opacity_by_class_n': _call_vs_function(
-            ['OpacityByClassN'],
-            class_name,
-        ),
-        'pen_color_by_class': _color_to_tuple_string(
-            _call_vs_function(['PenColorByClass'], class_name)
         ),
     }
     return attrs

--- a/export_classes_csv.py
+++ b/export_classes_csv.py
@@ -205,9 +205,6 @@ def get_class_attributes(class_name):
             ['CLDropShadowEnabled'],
             class_name,
         ),
-        'fill_color_by_class': _color_to_tuple_string(
-            _call_vs_function(['FillColorByClass'], class_name)
-        ),
         'fill_pattern_by_class': _call_vs_function(
             ['FPatByClass'],
             class_name,

--- a/tests/test_export_classes_csv.py
+++ b/tests/test_export_classes_csv.py
@@ -111,7 +111,7 @@ def make_vs_stub(tmp_path, classes, return_file_path=False):
     vs.GetClVectorFill = lambda name: 'pattern'
     vs.CLDropShadowEnabled = lambda name: True
     vs.GetClassOptions = lambda name: 3
-    vs.GetCLDrpShadowData = lambda name: (1, 2, 3, 4, 5, 6)
+    vs.GetCLDrpShadowData = lambda name: (1, 2, 3, 4, 5, 6, 7, 8)
     vs.GetClLSN = lambda name: 12
     vs.GetClTextStyleRef = lambda name: 'ref'
     if return_file_path:
@@ -152,7 +152,7 @@ def test_get_class_attributes(tmp_path):
     assert attrs['vector_fill'] == 'pattern'
     assert attrs['drop_shadow_enabled'] is True
     assert attrs['class_options'] == 3
-    assert attrs['drop_shadow_data'] == (1, 2, 3, 4, 5, 6)
+    assert attrs['drop_shadow_data'] == (1, 2, 3, 4, 5, 6, 7, 8)
     assert attrs['line_style_n'] == 12
     assert attrs['text_style_ref'] == 'ref'
 
@@ -180,7 +180,7 @@ def test_main_exports_csv(tmp_path):
     assert rows[0]['line_weight'] == '15'
     assert rows[0]['line_color_fore'] == '(1, 1, 1)'
     assert rows[0]['vector_fill'] == 'pattern'
-    assert rows[0]['drop_shadow_data'] == '(1, 2, 3, 4, 5, 6)'
+    assert rows[0]['drop_shadow_data'] == '(1, 2, 3, 4, 5, 6, 7, 8)'
     assert rows[0]['visibility'] == '0'
     assert vs_stub.alerts
     assert 'Class settings exported to:' in vs_stub.alerts[-1]

--- a/tests/test_export_classes_csv.py
+++ b/tests/test_export_classes_csv.py
@@ -110,20 +110,10 @@ def make_vs_stub(tmp_path, classes, return_file_path=False):
     vs.GetClOpacityN = lambda name: 75
     vs.GetClVectorFill = lambda name: 'pattern'
     vs.CLDropShadowEnabled = lambda name: True
-    vs.FPatByClass = lambda name: 10
     vs.GetClassOptions = lambda name: 3
     vs.GetCLDrpShadowData = lambda name: (1, 2, 3, 4, 5, 6)
     vs.GetClLSN = lambda name: 12
     vs.GetClTextStyleRef = lambda name: 'ref'
-    vs.GrayClass = lambda name: 0
-    vs.HideClass = lambda name: 0
-    vs.LSByClass = lambda name: True
-    vs.LWByClass = lambda name: True
-    vs.MarkerByClass = lambda name: 'marker'
-    vs.NameClass = lambda name: name
-    vs.OpacityByClass = lambda name: True
-    vs.OpacityByClassN = lambda name: True
-    vs.PenColorByClass = lambda name: 13
     if return_file_path:
         vs.GetFPathName = lambda: str(tmp_path / 'doc.vwx')
     else:
@@ -161,20 +151,10 @@ def test_get_class_attributes(tmp_path):
     assert attrs['opacity_n'] == 75
     assert attrs['vector_fill'] == 'pattern'
     assert attrs['drop_shadow_enabled'] is True
-    assert attrs['fill_pattern_by_class'] == 10
     assert attrs['class_options'] == 3
     assert attrs['drop_shadow_data'] == (1, 2, 3, 4, 5, 6)
     assert attrs['line_style_n'] == 12
     assert attrs['text_style_ref'] == 'ref'
-    assert attrs['gray_class'] == 0
-    assert attrs['hide_class'] == 0
-    assert attrs['line_style_by_class'] is True
-    assert attrs['line_weight_by_class'] is True
-    assert attrs['marker_by_class'] == 'marker'
-    assert attrs['name_class'] == 'Test'
-    assert attrs['opacity_by_class'] is True
-    assert attrs['opacity_by_class_n'] is True
-    assert attrs['pen_color_by_class'] == '(13, 13, 13)'
 
 
 def test_main_exports_csv(tmp_path):
@@ -201,7 +181,6 @@ def test_main_exports_csv(tmp_path):
     assert rows[0]['line_color_fore'] == '(1, 1, 1)'
     assert rows[0]['vector_fill'] == 'pattern'
     assert rows[0]['drop_shadow_data'] == '(1, 2, 3, 4, 5, 6)'
-    assert rows[0]['marker_by_class'] == 'marker'
     assert rows[0]['visibility'] == '0'
     assert vs_stub.alerts
     assert 'Class settings exported to:' in vs_stub.alerts[-1]

--- a/tests/test_export_classes_csv.py
+++ b/tests/test_export_classes_csv.py
@@ -110,7 +110,6 @@ def make_vs_stub(tmp_path, classes, return_file_path=False):
     vs.GetClOpacityN = lambda name: 75
     vs.GetClVectorFill = lambda name: 'pattern'
     vs.CLDropShadowEnabled = lambda name: True
-    vs.FillColorByClass = lambda name: 9
     vs.FPatByClass = lambda name: 10
     vs.GetClassOptions = lambda name: 3
     vs.GetCLDrpShadowData = lambda name: (1, 2, 3, 4, 5, 6)
@@ -162,7 +161,6 @@ def test_get_class_attributes(tmp_path):
     assert attrs['opacity_n'] == 75
     assert attrs['vector_fill'] == 'pattern'
     assert attrs['drop_shadow_enabled'] is True
-    assert attrs['fill_color_by_class'] == '(9, 9, 9)'
     assert attrs['fill_pattern_by_class'] == 10
     assert attrs['class_options'] == 3
     assert attrs['drop_shadow_data'] == (1, 2, 3, 4, 5, 6)
@@ -202,7 +200,6 @@ def test_main_exports_csv(tmp_path):
     assert rows[0]['line_weight'] == '15'
     assert rows[0]['line_color_fore'] == '(1, 1, 1)'
     assert rows[0]['vector_fill'] == 'pattern'
-    assert rows[0]['fill_color_by_class'] == '(9, 9, 9)'
     assert rows[0]['drop_shadow_data'] == '(1, 2, 3, 4, 5, 6)'
     assert rows[0]['marker_by_class'] == 'marker'
     assert rows[0]['visibility'] == '0'

--- a/tests/test_export_classes_csv.py
+++ b/tests/test_export_classes_csv.py
@@ -109,6 +109,22 @@ def make_vs_stub(tmp_path, classes, return_file_path=False):
     vs.GetClassByStyle = lambda name: False
     vs.GetClOpacityN = lambda name: 75
     vs.GetClVectorFill = lambda name: 'pattern'
+    vs.CLDropShadowEnabled = lambda name: True
+    vs.FillColorByClass = lambda name: 9
+    vs.FPatByClass = lambda name: 10
+    vs.GetClassOptions = lambda name: 3
+    vs.GetCLDrpShadowData = lambda name: (1, 2, 3, 4, 5, 6)
+    vs.GetClLSN = lambda name: 12
+    vs.GetClTextStyleRef = lambda name: 'ref'
+    vs.GrayClass = lambda name: 0
+    vs.HideClass = lambda name: 0
+    vs.LSByClass = lambda name: True
+    vs.LWByClass = lambda name: True
+    vs.MarkerByClass = lambda name: 'marker'
+    vs.NameClass = lambda name: name
+    vs.OpacityByClass = lambda name: True
+    vs.OpacityByClassN = lambda name: True
+    vs.PenColorByClass = lambda name: 13
     if return_file_path:
         vs.GetFPathName = lambda: str(tmp_path / 'doc.vwx')
     else:
@@ -145,6 +161,22 @@ def test_get_class_attributes(tmp_path):
     assert attrs['by_style'] is False
     assert attrs['opacity_n'] == 75
     assert attrs['vector_fill'] == 'pattern'
+    assert attrs['drop_shadow_enabled'] is True
+    assert attrs['fill_color_by_class'] == '(9, 9, 9)'
+    assert attrs['fill_pattern_by_class'] == 10
+    assert attrs['class_options'] == 3
+    assert attrs['drop_shadow_data'] == (1, 2, 3, 4, 5, 6)
+    assert attrs['line_style_n'] == 12
+    assert attrs['text_style_ref'] == 'ref'
+    assert attrs['gray_class'] == 0
+    assert attrs['hide_class'] == 0
+    assert attrs['line_style_by_class'] is True
+    assert attrs['line_weight_by_class'] is True
+    assert attrs['marker_by_class'] == 'marker'
+    assert attrs['name_class'] == 'Test'
+    assert attrs['opacity_by_class'] is True
+    assert attrs['opacity_by_class_n'] is True
+    assert attrs['pen_color_by_class'] == '(13, 13, 13)'
 
 
 def test_main_exports_csv(tmp_path):
@@ -166,9 +198,13 @@ def test_main_exports_csv(tmp_path):
     assert 'line_thickness' in rows[0]
     assert 'shadow_offset_x' in rows[0]
     assert 'use_text_style' in rows[0]
+    assert 'drop_shadow_enabled' in rows[0]
     assert rows[0]['line_weight'] == '15'
     assert rows[0]['line_color_fore'] == '(1, 1, 1)'
     assert rows[0]['vector_fill'] == 'pattern'
+    assert rows[0]['fill_color_by_class'] == '(9, 9, 9)'
+    assert rows[0]['drop_shadow_data'] == '(1, 2, 3, 4, 5, 6)'
+    assert rows[0]['marker_by_class'] == 'marker'
     assert rows[0]['visibility'] == '0'
     assert vs_stub.alerts
     assert 'Class settings exported to:' in vs_stub.alerts[-1]


### PR DESCRIPTION
## Summary
- add many Vectorworks class API calls in `export_classes_csv.py`
- cover new fields in the test suite via stub functions
- document new export fields in the READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684594ae74fc8325b48fa54a00b95f98