### PR TITLE
Fix tests for GetClLSN

### DIFF
--- a/tests/test_export_classes_csv.py
+++ b/tests/test_export_classes_csv.py
@@ -32,7 +32,6 @@ def make_vs_stub(tmp_path, classes, return_file_path=False):
 
     vs.GetClassLineStyle = lambda name: 3
     vs.GetClassLS = lambda name: 3
-    vs.GetClLS = lambda name: 3
 
     vs.GetClassFillPattern = lambda name: 4
     vs.GetClassFPat = lambda name: 4


### PR DESCRIPTION
## Summary
- update `test_export_classes_csv` stub to drop unused `GetClLS`
- keep calling `GetClLSN` fallback in `export_classes_csv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c6512ad083259f9fc40c517885a5