### PR TITLE
Fix get_pio_fields with variable return length

### DIFF
--- a/plugin_object_utils/get_pio_fields.py
+++ b/plugin_object_utils/get_pio_fields.py
@@ -41,10 +41,22 @@ def get_object_var_value(handle, index):
 
 
 def get_pio_fields(handle):
-    """Return a list of (name, value) for the parameters of a plug-in object."""
+    """Return a list of ``(name, value)`` for the parameters of a plug-in object.
+
+    ``GetCustomObjectInfo`` historically returned four values, but newer
+    Vectorworks versions include a leading boolean and may append additional
+    values. The implementation therefore accepts either variant.
+    """
     result = vs.GetCustomObjectInfo()
-    obj_name, obj_handle, record_handle, wall_handle = result[:4]
-    if handle != obj_handle:
+
+    # Normalize the return signature to ``(success, name, obj, record, wall)``.
+    if len(result) >= 5:
+        success, obj_name, obj_handle, record_handle, wall_handle = result[:5]
+    else:
+        success = True
+        obj_name, obj_handle, record_handle, wall_handle = result[:4]
+
+    if not success or handle != obj_handle:
         return []
 
     num_params = vs.NumFields(record_handle)

--- a/plugin_object_utils/get_pio_fields.py
+++ b/plugin_object_utils/get_pio_fields.py
@@ -42,7 +42,8 @@ def get_object_var_value(handle, index):
 
 def get_pio_fields(handle):
     """Return a list of (name, value) for the parameters of a plug-in object."""
-    obj_name, obj_handle, record_handle, wall_handle = vs.GetCustomObjectInfo()
+    result = vs.GetCustomObjectInfo()
+    obj_name, obj_handle, record_handle, wall_handle = result[:4]
     if handle != obj_handle:
         return []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import sys
+import types
+from pathlib import Path
+
+# Provide a minimal stub for the Vectorworks `vs` module so modules can be
+# imported outside of Vectorworks during testing.
+sys.modules.setdefault('vs', types.SimpleNamespace())
+
+# Ensure the repository root is on sys.path so test modules can import scripts
+# located there.
+repo_root = Path(__file__).resolve().parents[1]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))

--- a/tests/test_get_pio_fields.py
+++ b/tests/test_get_pio_fields.py
@@ -4,14 +4,19 @@ from pathlib import Path
 import runpy
 
 
-def make_vs_stub(num_returns=5):
+def make_vs_stub(num_returns=5, success=True):
     vs = types.SimpleNamespace()
     vs.alerts = []
+    base = (success, 'obj', 'obj_handle', 'rec_handle', 'wall_handle')
+
     if num_returns == 4:
-        vs.GetCustomObjectInfo = lambda: ('obj', 'obj_handle', 'rec_handle', 'wall_handle')
+        # Historical API without the leading boolean
+        return_vals = base[1:]
     else:
-        values = ('obj', 'obj_handle', 'rec_handle', 'wall_handle', 'extra')
-        vs.GetCustomObjectInfo = lambda: values[:num_returns]
+        extras = tuple(f'extra{i}' for i in range(num_returns - 5)) if num_returns > 5 else ()
+        return_vals = base + extras
+
+    vs.GetCustomObjectInfo = lambda: return_vals
 
     vs.NumFields = lambda record: 2
     vs.GetName = lambda record: 'rec'
@@ -35,18 +40,26 @@ def load_module(vs_stub):
     return runpy.run_path(str(path))
 
 
-def test_get_pio_fields_with_extra_values(tmp_path):
-    vs_stub = make_vs_stub(5)
+def test_get_pio_fields_with_bool_and_extra(tmp_path):
+    # bool flag + 4 expected values + one extra value
+    vs_stub = make_vs_stub(6)
     mod = load_module(vs_stub)
     fields = mod['get_pio_fields']('obj_handle')
     assert fields == [('field1', 'rec_field1'), ('field2', 'rec_field2')]
 
 
-def test_get_pio_fields_four_values(tmp_path):
+def test_get_pio_fields_no_bool(tmp_path):
     vs_stub = make_vs_stub(4)
     mod = load_module(vs_stub)
     fields = mod['get_pio_fields']('obj_handle')
     assert fields == [('field1', 'rec_field1'), ('field2', 'rec_field2')]
+
+
+def test_get_pio_fields_failure_flag(tmp_path):
+    vs_stub = make_vs_stub(5, success=False)
+    mod = load_module(vs_stub)
+    fields = mod['get_pio_fields']('obj_handle')
+    assert fields == []
 
 
 def test_get_pio_fields_wrong_handle(tmp_path):

--- a/tests/test_get_pio_fields.py
+++ b/tests/test_get_pio_fields.py
@@ -1,0 +1,56 @@
+import sys
+import types
+from pathlib import Path
+import runpy
+
+
+def make_vs_stub(num_returns=5):
+    vs = types.SimpleNamespace()
+    vs.alerts = []
+    if num_returns == 4:
+        vs.GetCustomObjectInfo = lambda: ('obj', 'obj_handle', 'rec_handle', 'wall_handle')
+    else:
+        values = ('obj', 'obj_handle', 'rec_handle', 'wall_handle', 'extra')
+        vs.GetCustomObjectInfo = lambda: values[:num_returns]
+
+    vs.NumFields = lambda record: 2
+    vs.GetName = lambda record: 'rec'
+    vs.GetFldName = lambda record, idx: f'field{idx}'
+    vs.GetRField = lambda h, rec, fld: f'{rec}_{fld}'
+    vs.GetObjectVariableString = lambda h, i: ''
+    vs.GetObjectVariableReal = lambda h, i: 0
+    vs.GetObjectVariableInt = lambda h, i: 0
+    vs.GetObjectVariableLongInt = lambda h, i: 0
+    vs.GetObjectVariableBoolean = lambda h, i: False
+    vs.GetObjectVariableHandle = lambda h, i: None
+    vs.FSActLayer = lambda: 'obj_handle'
+    vs.AlrtDialog = lambda msg: vs.alerts.append(msg)
+    return vs
+
+
+def load_module(vs_stub):
+    sys.modules['vs'] = vs_stub
+    repo_root = Path(__file__).resolve().parents[1]
+    path = repo_root / 'plugin_object_utils' / 'get_pio_fields.py'
+    return runpy.run_path(str(path))
+
+
+def test_get_pio_fields_with_extra_values(tmp_path):
+    vs_stub = make_vs_stub(5)
+    mod = load_module(vs_stub)
+    fields = mod['get_pio_fields']('obj_handle')
+    assert fields == [('field1', 'rec_field1'), ('field2', 'rec_field2')]
+
+
+def test_get_pio_fields_four_values(tmp_path):
+    vs_stub = make_vs_stub(4)
+    mod = load_module(vs_stub)
+    fields = mod['get_pio_fields']('obj_handle')
+    assert fields == [('field1', 'rec_field1'), ('field2', 'rec_field2')]
+
+
+def test_get_pio_fields_wrong_handle(tmp_path):
+    vs_stub = make_vs_stub(5)
+    mod = load_module(vs_stub)
+    fields = mod['get_pio_fields']('other')
+    assert fields == []


### PR DESCRIPTION
## Summary
- handle Vectorworks API returning more than four values from `GetCustomObjectInfo`
- add tests for `get_pio_fields`
- provide pytest conftest to stub `vs` module and add repo root to path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857dc0322888325863e54939dcca6a8