### PR TITLE
Add alert after GetCustomObjectInfo call

### DIFF
--- a/plugin_object_utils/get_pio_fields.py
+++ b/plugin_object_utils/get_pio_fields.py
@@ -48,6 +48,7 @@ def get_pio_fields(handle):
     values. The implementation therefore accepts either variant.
     """
     result = vs.GetCustomObjectInfo()
+    vs.AlrtDialog(str(result))
 
     # Normalize the return signature to ``(success, name, obj, record, wall)``.
     if len(result) >= 5:


### PR DESCRIPTION
## Summary
- show return value of `GetCustomObjectInfo` in an alert dialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e3c873d48325b34dd80ed6b49829